### PR TITLE
Update hardware.md

### DIFF
--- a/_neptune_4/hardware.md
+++ b/_neptune_4/hardware.md
@@ -340,7 +340,7 @@ These specifications were taken from the Goodix website.
 
 This is wired directly into a serial adapter, and can not be used as an actual USB port for the host. It will be accessible to the host on `/dev/ttyS2`.
 
-This serial connection can be *extremely* helpful when SSH is not available, such as when needing to access the bootloader or an alternative OS. Connect at `5000000` baud.
+This serial connection can be *extremely* helpful when SSH is not available, such as when needing to access the bootloader or an alternative OS. Connect at `1500000` baud.
 
 ## USB 2.0 Header
 

--- a/_neptune_4/hardware.md
+++ b/_neptune_4/hardware.md
@@ -340,7 +340,7 @@ These specifications were taken from the Goodix website.
 
 This is wired directly into a serial adapter, and can not be used as an actual USB port for the host. It will be accessible to the host on `/dev/ttyS2`.
 
-This serial connection can be *extremely* helpful when SSH is not available, such as when needing to access the bootloader or an alternative OS. Connect at `1500000` baud.
+This serial connection can be *extremely* helpful when SSH is not available, such as when needing to access the bootloader or an alternative OS. Different board revisions require different baud rates. `5000000` and `1500000` baud have been verified to work for different revisions.
 
 ## USB 2.0 Header
 


### PR DESCRIPTION
The correct baud rate for the serial interface (CHR340) on the USB-C front panel connector appears to be 1500000.  From /lib/systemd/system/serial-getty@ttyS2.service...

ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud 1500000,115200,38400,9600 %I $TERM

Confirmed on my Neptune 4 Plus.